### PR TITLE
Explict Install Of Yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ COPY --chown=ruby:ruby Gemfile* ./
 RUN bundle install
 
 COPY --chown=ruby:ruby package.json *yarn* ./
+RUN npm install - yarn
+RUN yarn --version
 RUN yarn install
 
 ARG RAILS_ENV="development"


### PR DESCRIPTION
# About

We have a candidate saying that their compose is not working due to `yarn` issues. I'm 99% sure it's a part of the image we're using but let's install it explicitly via `npm` just in case we missing something on our end.